### PR TITLE
Add research ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 `learnr` or `quarto-live` resources with linting, reusable MCQ banks, and
 export/report tooling.
 
+## Part of the research ecosystem
+
+This repository is part of Aurélien Nicosia's open research and teaching ecosystem in computational statistics, scientific R software, reproducible data science and statistical education.
+
+* Research Lab: [https://aureliennicosiaulaval.github.io/web_site/research-lab.html](https://aureliennicosiaulaval.github.io/web_site/research-lab.html)
+* GitHub profile: [https://github.com/AurelienNicosiaULaval](https://github.com/AurelienNicosiaULaval)
+* Related projects: [`learnrTrackR`](https://github.com/AurelienNicosiaULaval/learnrTrackR), [`site_ressources_SSD`](https://github.com/AurelienNicosiaULaval/site_ressources_SSD), [`donnees-bleues`](https://github.com/AurelienNicosiaULaval/donnees-bleues)
+
 ## Installation
 
 ```r


### PR DESCRIPTION
## Summary

Add a short `Part of the research ecosystem` section to `README.md`.

## Scope

- README-only change.
- No code changes.
- No license changes.
- No DOI changes.
- No GitHub Pages URL changes.
- No repository settings changes.

## Related links added

- Research Lab
- GitHub profile
- `learnrTrackR`
- `site_ressources_SSD`
- `donnees-bleues`

## Validation

- Confirmed only `README.md` changed.
- Checked added links return HTTP 200.
- Checked no sensitive repository links were added.
